### PR TITLE
GachaKit // Use Trie to handle incorrect Genshin item names.

### DIFF
--- a/Packages/GachaKit/Sources/GachaKit/Backends/GachaExchange/UIGFModels/OldModels/GIGF.swift
+++ b/Packages/GachaKit/Sources/GachaKit/Backends/GachaExchange/UIGFModels/OldModels/GIGF.swift
@@ -402,14 +402,32 @@ extension GIGF {
         }
 
         var revDB = [String: Int]()
+        var revDBDeducted = [String: Int]() // 复用表。
         let listBackup = list
         languageEnumeration: while !languages.isEmpty, let language = languages.first {
             var languageMismatchDetected = false
             revDB = language.makeRevDB()
             listItemEnumeration: for listIndex in 0 ..< list.count {
-                guard Int(list[listIndex].itemID) == nil else { continue }
+                guard list[listIndex].itemID.isNotInt else { continue }
                 /// 只要没查到结果，就可以认定当前的语言匹配有误。
-                guard let newItemID = revDB[list[listIndex].name] else {
+                lazy var trie = GachaMeta.Trie(words: [String](revDB.keys))
+                let itemNameFromOldCDMO = list[listIndex].name
+                let newItemID: Int?
+                if !revDB.keys.contains(itemNameFromOldCDMO), !revDBDeducted.keys.contains(itemNameFromOldCDMO) {
+                    /// 只允许有最多一个错别字。
+                    let matched = trie.findSimilarWords(against: itemNameFromOldCDMO, maxDistance: 1)
+                    if matched.count == 1, let matchedUniqueResult = matched.first {
+                        /// 如果只有一个匹配结果的话，那应该就是正确结果。
+                        revDBDeducted[itemNameFromOldCDMO] = revDB[matchedUniqueResult] // 将该结果留着复用。
+                        newItemID = revDB[matchedUniqueResult]
+                    } else {
+                        /// 如果有多个匹配结果的话，现阶段不处理。回头实作一个画面让用户确认。
+                        newItemID = nil
+                    }
+                } else {
+                    newItemID = revDB[itemNameFromOldCDMO] ?? revDBDeducted[itemNameFromOldCDMO]
+                }
+                guard let newItemID else {
                     languageMismatchDetected = true
                     break listItemEnumeration
                 }


### PR DESCRIPTION
在汇入 UIGFv2 或继承原神披萨小助手的资料时，有些物品名称可能包含错别字。
这个 PR 处理那种仅含有一个错别字、且可推断结果只有一个正确结果的情形。
推断方法是使用 Trie，且按需构筑之，以减少运算时长开销。

抽象出来的逻辑：
```swift

enum GachaMeta {}

// MARK: - GachaMeta.Trie

extension GachaMeta {
    class Trie {
        // MARK: Lifecycle

        public init() {}

        public init(words: [String]) {
            words.forEach(insert)
        }

        // MARK: Internal

        func insert(_ word: String) {
            var currentNode = root
            for char in word {
                if currentNode.children[char] == nil {
                    currentNode.children[char] = Node()
                }
                currentNode = currentNode.children[char]!
            }
            currentNode.isWord = true
        }

        // 在 Trie 中查找接近的词语
        func findSimilarWords(
            against word: String,
            maxDistance: Int
        )
            -> [String] {
            let trie = self
            var matchedWords: [String] = []
            let initialDistance = Array(0 ... word.count) // 初始化编辑距离
            trie.getRoot().InternalSearch(
                target: word,
                currentWord: "",
                maxDistance: Double(maxDistance),
                currentDistance: initialDistance.map(Double.init),
                results: &matchedWords
            )
            return matchedWords
        }

        // MARK: Fileprivate

        fileprivate class Node {
            var children: [Character: Node] = [:]
            var isWord: Bool = false
        }

        fileprivate func getRoot() -> Node {
            root
        }

        // MARK: Private

        private let root = Node()
    }
}

extension GachaMeta.Trie.Node {
    /// key 应该是米哈游官方用字，而 value 是其可能的笔画相似的错别字或非官方用字。
    /// 抽卡记录的原始数据原则上只能使用米哈游官方用字，哪怕米哈游自己用了错别字。
    private static let similarCharacters: [Character: [Character]] = [
        "曚": ["朦"],
    ]

    fileprivate func InternalSearch(
        target: String,
        currentWord: String,
        maxDistance: Double,
        currentDistance: [Double],
        results: inout [String],
        similarCharacters: [Character: [Character]]? = nil
    ) {
        let similarCharacters = similarCharacters ?? Self.similarCharacters
        // 如果当前节点是一个完整单词，并且编辑距离符合条件
        if isWord, let lastDistance = currentDistance.last, lastDistance <= maxDistance {
            results.append(currentWord)
        }

        // 遍历节点的每个子节点
        children.forEach { char, childNode in
            var nextDistance: [Double] = [currentDistance[0] + 1] // 第 0 列: 插入操作
            for (i, targetChar) in target.enumerated() {
                let cost: Double
                if char == targetChar {
                    cost = 0
                } else if similarCharacters[char]?.contains(targetChar) == true {
                    cost = 0.5
                } else {
                    cost = 1
                }
                nextDistance.append(
                    min(
                        currentDistance[i + 1] + 1, // 删除
                        nextDistance[i] + 1, // 插入
                        currentDistance[i] + cost // 替换或相似
                    )
                )
            }

            // 如果最小编辑距离在允许范围内，继续搜寻子节点
            if nextDistance.min()! <= maxDistance {
                childNode.InternalSearch(
                    target: target,
                    currentWord: currentWord + String(char),
                    maxDistance: maxDistance,
                    currentDistance: nextDistance,
                    results: &results,
                    similarCharacters: similarCharacters
                )
            }
        }
    }
}

let trie = GachaMeta.Trie(words: ["腾云月", "曚云之月", "野兽先辈"])
let matched = trie.findSimilarWords(against: "朦云之月", maxDistance: 1)
print(matched)
```