### PR TITLE
Repo // Switch to Alamofire in lieu of URLSession.

### DIFF
--- a/Packages/AbyssRankKit/Package.swift
+++ b/Packages/AbyssRankKit/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .package(path: "../EnkaKit"),
         .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols.git", .upToNextMajor(from: "6.2.0")),
         .package(url: "https://github.com/sindresorhus/Defaults", .upToNextMajor(from: "9.0.2")),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.2")),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -31,6 +32,7 @@ let package = Package(
                 .product(name: "EnkaKit", package: "EnkaKit"),
                 .product(name: "SFSafeSymbols", package: "SFSafeSymbols"),
                 .product(name: "Defaults", package: "Defaults"),
+                .product(name: "Alamofire", package: "Alamofire"),
             ]
         ),
         .testTarget(

--- a/Packages/EnkaKit/Package.swift
+++ b/Packages/EnkaKit/Package.swift
@@ -29,6 +29,9 @@ let package = Package(
         .package(
             url: "https://github.com/pizza-studio/ArtifactRatingDB.git", .upToNextMajor(from: "1.1.3")
         ),
+        .package(
+            url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.2")
+        ),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -44,6 +47,7 @@ let package = Package(
                 .product(name: "ArtifactRatingDB", package: "ArtifactRatingDB"),
                 .product(name: "SFSafeSymbols", package: "SFSafeSymbols"),
                 .product(name: "Defaults", package: "Defaults"),
+                .product(name: "Alamofire", package: "Alamofire"),
             ],
             resources: [
                 .process("Assets/"),

--- a/Packages/EnkaKit/Sources/EnkaKit/EnkaKitBackend/HakushinQuery/HakushinNameCardQuery_GI.swift
+++ b/Packages/EnkaKit/Sources/EnkaKit/EnkaKitBackend/HakushinQuery/HakushinNameCardQuery_GI.swift
@@ -6,6 +6,7 @@
 // 由于用来查询的论据（角色 ID、道具 ID、服装 ID 等）并不出自内鬼泄漏的内容，
 // 所以 App 据此在 Hakushin 只能拿到公开正式版游戏的结果。
 
+import Alamofire
 import Foundation
 import PZBaseKit
 
@@ -42,10 +43,14 @@ extension HakushinCharacter4GI {
             initID += "-\(charIDStr.suffix(1))"
         }
         let urlStr = "https://api.hakush.in/gi/data/en/character/\(initID).json"
-        let (data, _) = try await URLSession.shared.data(from: urlStr.asURL)
+
+        // 同时使用 Alamofire 的 responseDecodable 直接解析 JSON
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromPascalCase
-        return try decoder.decode(Self.self, from: data)
+
+        return try await AF.request(urlStr)
+            .serializingDecodable(Self.self, decoder: decoder)
+            .value
     }
 
     private func namecardURLStr() -> String {

--- a/Packages/GachaKit/Package.swift
+++ b/Packages/GachaKit/Package.swift
@@ -35,6 +35,9 @@ let package = Package(
         .package(
             url: "https://github.com/elai950/AlertToast", .upToNextMajor(from: "1.3.9")
         ),
+        .package(
+            url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.2")
+        ),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -51,6 +54,7 @@ let package = Package(
                 .product(name: "Defaults", package: "Defaults"),
                 .product(name: "CoreXLSX", package: "CoreXLSX"),
                 .product(name: "AlertToast", package: "AlertToast"),
+                .product(name: "Alamofire", package: "Alamofire"),
             ],
             resources: [
                 .process("Resources/"),

--- a/Packages/PZDictionaryKit/Package.swift
+++ b/Packages/PZDictionaryKit/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
     dependencies: [
         .package(path: "../PZKit"),
         .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols.git", .upToNextMajor(from: "6.2.0")),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.2")),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -26,6 +27,7 @@ let package = Package(
             dependencies: [
                 .product(name: "PZBaseKit", package: "PZKit"),
                 .product(name: "SFSafeSymbols", package: "SFSafeSymbols"),
+                .product(name: "Alamofire", package: "Alamofire"),
             ]
         ),
         .testTarget(

--- a/Packages/PZDictionaryKit/Sources/PZDictionaryKit/PZDict_Backends/PZDict_GameEnumImpl.swift
+++ b/Packages/PZDictionaryKit/Sources/PZDictionaryKit/PZDict_Backends/PZDict_GameEnumImpl.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Foundation
 import PZBaseKit
 
@@ -31,9 +32,12 @@ extension Pizza.SupportedGame {
         components.host = dictionaryServerHost
         components.path = "/v1/translations/\(query)"
         components.queryItems = [.init(name: "page", value: "\(page)"), .init(name: "page_size", value: "\(pageSize)")]
-        let url = components.url!
-        let request = URLRequest(url: url)
-        let (data, _) = try await URLSession.shared.data(for: request)
-        return try JSONDecoder().decode(TranslationResult.self, from: data)
+        guard let url = components.url else {
+            throw AFError.invalidURL(url: components)
+        }
+
+        return try await AF.request(url)
+            .serializingDecodable(TranslationResult.self)
+            .value
     }
 }

--- a/Packages/PZHoYoLabKit/Package.swift
+++ b/Packages/PZHoYoLabKit/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         .package(path: "../WallpaperKit"),
         .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols.git", .upToNextMajor(from: "6.2.0")),
         .package(url: "https://github.com/sindresorhus/Defaults", .upToNextMajor(from: "9.0.2")),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.2")),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -33,6 +34,7 @@ let package = Package(
                 .product(name: "WallpaperKit", package: "WallpaperKit"),
                 .product(name: "SFSafeSymbols", package: "SFSafeSymbols"),
                 .product(name: "Defaults", package: "Defaults"),
+                .product(name: "Alamofire", package: "Alamofire"),
             ],
             resources: [
                 .process("Resources/"),

--- a/Packages/PZHoYoLabKit/Sources/PZHoYoLabKit/FeatureModules/AbyssReport/HoYoAPIImpl/AbyssReportAPI.swift
+++ b/Packages/PZHoYoLabKit/Sources/PZHoYoLabKit/FeatureModules/AbyssReport/HoYoAPIImpl/AbyssReportAPI.swift
@@ -92,7 +92,7 @@ extension HoYo {
         )
         request.printDebugIntelIfDebugMode()
 
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let data = try await request.serializingData().value
 
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.AbyssReportData4GI()")
     }
@@ -148,7 +148,7 @@ extension HoYo {
         )
         request.printDebugIntelIfDebugMode()
 
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let data = try await request.serializingData().value
 
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.abyssReportData4HSR()")
     }

--- a/Packages/PZHoYoLabKit/Sources/PZHoYoLabKit/FeatureModules/CharacterInventory/HoYoAPIImpl/CharInventoryAPI.swift
+++ b/Packages/PZHoYoLabKit/Sources/PZHoYoLabKit/FeatureModules/CharacterInventory/HoYoAPIImpl/CharInventoryAPI.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Defaults
 import EnkaKit
 import Foundation
@@ -80,7 +81,7 @@ extension HoYo {
         )
         request1.printDebugIntelIfDebugMode()
 
-        let (data1, _) = try await URLSession.shared.data(for: request1)
+        let data1 = try await request1.serializingData().value
 
         // #if DEBUG
         // print("-----------------------------------")
@@ -111,7 +112,7 @@ extension HoYo {
         )
         request2.printDebugIntelIfDebugMode()
 
-        let (data2, _) = try await URLSession.shared.data(for: request2)
+        let data2 = try await request2.serializingData().value
 
         // #if DEBUG
         // print("-----------------------------------")
@@ -176,7 +177,7 @@ extension HoYo {
         )
         request.printDebugIntelIfDebugMode()
 
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let data = try await request.serializingData().value
 
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.characterInventory4HSR()") {
             HYQueriedModels.HYLAvatarDetail4HSR.cacheLocalHoYoAvatars(uid: uid, data: data)

--- a/Packages/PZHoYoLabKit/Sources/PZHoYoLabKit/FeatureModules/Ledger/HoYoAPIImpl/LedgerDataAPI.swift
+++ b/Packages/PZHoYoLabKit/Sources/PZHoYoLabKit/FeatureModules/Ledger/HoYoAPIImpl/LedgerDataAPI.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Foundation
 import PZAccountKit
 
@@ -88,7 +89,7 @@ extension HoYo {
         )
         request.printDebugIntelIfDebugMode()
 
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let data = try await request.serializingData().value
 
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.ledgerData4GI()")
     }
@@ -134,7 +135,7 @@ extension HoYo {
         )
         request.printDebugIntelIfDebugMode()
 
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let data = try await request.serializingData().value
 
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.ledgerData4HSR()")
     }

--- a/Packages/PZHoYoLabKit/Sources/PZHoYoLabKit/FeatureModules/TravelStats/HoYoAPIImpl/TravelStatsDataAPI.swift
+++ b/Packages/PZHoYoLabKit/Sources/PZHoYoLabKit/FeatureModules/TravelStats/HoYoAPIImpl/TravelStatsDataAPI.swift
@@ -76,7 +76,7 @@ extension HoYo {
         )
         request.printDebugIntelIfDebugMode()
 
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let data = try await request.serializingData().value
 
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.travelStatsData4GI()")
     }
@@ -119,7 +119,7 @@ extension HoYo {
         )
         request.printDebugIntelIfDebugMode()
 
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let data = try await request.serializingData().value
 
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.travelStatsData4HSR()")
     }

--- a/Packages/PZInGameEventKit/Package.swift
+++ b/Packages/PZInGameEventKit/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(
             url: "https://github.com/SFSafeSymbols/SFSafeSymbols.git", .upToNextMajor(from: "6.2.0")
         ),
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.2")),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -35,6 +36,7 @@ let package = Package(
                 .product(name: "WallpaperKit", package: "WallpaperKit"),
                 .product(name: "SFSafeSymbols", package: "SFSafeSymbols"),
                 .product(name: "Defaults", package: "Defaults"),
+                .product(name: "Alamofire", package: "Alamofire"),
             ],
             resources: [
                 .process("Resources/"),
@@ -42,7 +44,10 @@ let package = Package(
         ),
         .testTarget(
             name: "PZInGameEventKitTests",
-            dependencies: ["PZInGameEventKit"]
+            dependencies: [
+                "PZInGameEventKit",
+                .product(name: "Alamofire", package: "Alamofire"),
+            ]
         ),
     ]
 )

--- a/Packages/PZInGameEventKit/Sources/PZInGameEventKit/IGEBackends/OfficialFeedAPIByGame.swift
+++ b/Packages/PZInGameEventKit/Sources/PZInGameEventKit/IGEBackends/OfficialFeedAPIByGame.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Foundation
 import PZAccountKit
 import PZBaseKit
@@ -19,16 +20,21 @@ extension Pizza.SupportedGame {
             // EventContent
             await HoYo.waitFor300ms()
             let urlDataC = getOfficialEventFeedURL(server, lang: lang, isContent: true)
-            let dataC = try await URLSession.shared.data(from: urlDataC)
+            let dataC = try await AF.request(urlDataC)
+                .validate(statusCode: 200 ... 200).serializingData().value
             let objContent = try HoYoEventPack.HoYoEventContent.decodeFromMiHoYoAPIJSONResult(
-                data: dataC.0,
-                debugTag: ""
+                data: dataC,
+                debugTag: "getOfficialFeedPackageOnline.dataC"
             )
             // EventMeta
             await HoYo.waitFor300ms()
             let urlDataM = getOfficialEventFeedURL(server, lang: lang, isContent: false)
-            let dataM = try await URLSession.shared.data(from: urlDataM)
-            let objMeta = try HoYoEventPack.HoYoEventMeta.decodeFromMiHoYoAPIJSONResult(data: dataM.0, debugTag: "")
+            let dataM = try await AF.request(urlDataM)
+                .validate(statusCode: 200 ... 200).serializingData().value
+            let objMeta = try HoYoEventPack.HoYoEventMeta.decodeFromMiHoYoAPIJSONResult(
+                data: dataM,
+                debugTag: "getOfficialFeedPackageOnline.dataM"
+            )
             // Assemble
             return .success(.init(content: objContent, meta: objMeta))
         } catch {

--- a/Packages/PZInGameEventKit/Tests/PZInGameEventKitTests/PZInGameEventKitTests.swift
+++ b/Packages/PZInGameEventKit/Tests/PZInGameEventKitTests/PZInGameEventKitTests.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Defaults
 import Foundation
 import PZAccountKit
@@ -14,13 +15,13 @@ func testDecodingOnlineFetchedOfficialFeeds() async throws {
     for game in Pizza.SupportedGame.allCases {
         // Test EventContent
         let urlDataC = game.getOfficialEventFeedURL(.asia(game), lang: .langJP, isContent: true)
-        let dataC = try await URLSession.shared.data(from: urlDataC)
-        let objContent = try HoYoEventPack.HoYoEventContent.decodeFromMiHoYoAPIJSONResult(data: dataC.0, debugTag: "")
+        let resultC = try await AF.request(urlDataC).serializingData().value
+        let objContent = try HoYoEventPack.HoYoEventContent.decodeFromMiHoYoAPIJSONResult(data: resultC, debugTag: "")
         print(objContent.total)
         // Test EventMeta
         let urlDataM = game.getOfficialEventFeedURL(.asia(game), lang: .langJP, isContent: false)
-        let dataM = try await URLSession.shared.data(from: urlDataM)
-        let objMeta = try HoYoEventPack.HoYoEventMeta.decodeFromMiHoYoAPIJSONResult(data: dataM.0, debugTag: "")
+        let resultM = try await AF.request(urlDataM).serializingData().value
+        let objMeta = try HoYoEventPack.HoYoEventMeta.decodeFromMiHoYoAPIJSONResult(data: resultM, debugTag: "")
         print(objMeta.list.count)
     }
 }

--- a/Packages/PZKit/Package.swift
+++ b/Packages/PZKit/Package.swift
@@ -37,6 +37,9 @@ let package = Package(
         Package.Dependency.package(
             url: "https://github.com/prisma-ai/Sworm.git", .upToNextMajor(from: "1.1.0")
         )
+        Package.Dependency.package(
+            url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.2")
+        )
     },
     targets: buildTargets {
         // MARK: - Common Targets
@@ -47,6 +50,10 @@ let package = Package(
                 Target.Dependency.product(
                     name: "Defaults",
                     package: "Defaults"
+                )
+                Target.Dependency.product(
+                    name: "Alamofire",
+                    package: "Alamofire"
                 )
             },
             swiftSettings: sharedSwiftSettings

--- a/Packages/PZKit/Package.swift
+++ b/Packages/PZKit/Package.swift
@@ -66,6 +66,10 @@ let package = Package(
                     name: "Sworm",
                     package: "Sworm"
                 )
+                Target.Dependency.product(
+                    name: "Alamofire",
+                    package: "Alamofire"
+                )
             },
             resources: buildResources {
                 Resource.process("Resources/")

--- a/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/DailyNoteRelated/NoteAPI4GI.swift
+++ b/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/DailyNoteRelated/NoteAPI4GI.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Foundation
 import PZBaseKit
 
@@ -92,8 +93,7 @@ extension HoYo {
             additionalHeaders: additionalHeaders
         )
 
-        let (data, _) = try await URLSession.shared.data(for: request)
-
+        let data = try await request.serializingData().value
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.generalNote4GI()") {
             GeneralNote4GI.CacheSputnik.cache(data, uidWithGame: uidWithGame)
         }
@@ -125,7 +125,7 @@ extension HoYo {
             additionalHeaders: additionalHeaders
         )
 
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let data = try await request.serializingData().value
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.widgetNote4GI()") {
             WidgetNote4GI.CacheSputnik.cache(data, uidWithGame: uidWithGame)
         }

--- a/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/DailyNoteRelated/NoteAPI4HSR.swift
+++ b/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/DailyNoteRelated/NoteAPI4HSR.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Foundation
 import PZBaseKit
 
@@ -109,7 +110,7 @@ extension HoYo {
             additionalHeaders: additionalHeaders
         )
 
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let data = try await request.serializingData().value
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.hoyoLabNote4HSR()") {
             RealtimeNote4HSR.CacheSputnik.cache(data, uidWithGame: uidWithGame)
         }
@@ -144,7 +145,7 @@ extension HoYo {
             additionalHeaders: additionalHeaders
         )
 
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let data = try await request.serializingData().value
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.miyousheNote4HSR()") {
             RealtimeNote4HSR.CacheSputnik.cache(data, uidWithGame: uidWithGame)
         }

--- a/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/DailyNoteRelated/NoteAPI4ZZZ.swift
+++ b/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/DailyNoteRelated/NoteAPI4ZZZ.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Foundation
 import PZBaseKit
 
@@ -53,8 +54,7 @@ extension HoYo {
             additionalHeaders: additionalHeaders
         )
 
-        let (data, _) = try await URLSession.shared.data(for: request)
-
+        let data = try await request.serializingData().value
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.getNote4ZZZ") {
             Note4ZZZ.CacheSputnik.cache(data, uidWithGame: uidWithGame)
         }

--- a/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/LoginRelated/GetCookieTokenAPI/GetCookieTokenAPI.swift
+++ b/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/LoginRelated/GetCookieTokenAPI/GetCookieTokenAPI.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Foundation
 import PZBaseKit
 
@@ -21,8 +22,7 @@ extension HoYo {
             cookie: cookie,
             additionalHeaders: nil
         )
-        let (data, _) = try await URLSession.shared.data(for: request)
-
+        let data = try await request.serializingData().value
         let result = try GetCookieTokenResult.decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.cookieToken()")
 
         return result

--- a/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/LoginRelated/GetTokenAPI/GetTokenAPI.swift
+++ b/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/LoginRelated/GetTokenAPI/GetTokenAPI.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Foundation
 
 extension HoYo {
@@ -30,8 +31,7 @@ extension HoYo {
             cookie: nil
         )
 
-        let (data, _) = try await URLSession.shared.data(for: request)
-
+        let data = try await request.serializingData().value
         return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.getMultiTokenByLoginTicket()")
     }
 }

--- a/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/LoginRelated/QRCodeLoginAPI/QueryQRCodeStatus/QueryQRCodeAPI.swift
+++ b/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/LoginRelated/QRCodeLoginAPI/QueryQRCodeStatus/QueryQRCodeAPI.swift
@@ -2,26 +2,28 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Foundation
 
 extension HoYo {
     static public func queryQRCodeStatus(deviceId: UUID, ticket: String) async throws -> QueryQRCodeStatus {
-        var request = URLRequest(url: QRCodeShared.url4Query)
-        request.httpMethod = "POST"
-
         struct Body: Encodable {
             let appId: String
             let device: String
             let ticket: String
         }
 
+        let parameters = Body(appId: QRCodeShared.appID, device: deviceId.uuidString, ticket: ticket)
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
-        let body = Body(appId: QRCodeShared.appID, device: deviceId.uuidString, ticket: ticket)
-        let bodyData = try encoder.encode(body)
-        request.httpBody = bodyData
 
-        let (resultData, _) = try await URLSession.shared.data(for: request)
-        return try .decodeFromMiHoYoAPIJSONResult(data: resultData, debugTag: "HoYo.queryQRCodeStatus()")
+        let data = try await AF.request(
+            QRCodeShared.url4Query,
+            method: .post,
+            parameters: parameters,
+            encoder: JSONParameterEncoder(encoder: encoder)
+        ).serializingData().value
+
+        return try .decodeFromMiHoYoAPIJSONResult(data: data, debugTag: "HoYo.queryQRCodeStatus()")
     }
 }

--- a/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/LoginRelated/UserGameRolesAPI/UserGameRolesAPI.swift
+++ b/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/LoginRelated/UserGameRolesAPI/UserGameRolesAPI.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Foundation
 
 extension HoYo {
@@ -21,8 +22,7 @@ extension HoYo {
             cookie: cookie
         )
 
-        let (data, _) = try await URLSession.shared.data(for: request)
-
+        let data = try await request.serializingData().value
         let list = try FetchedAccountDecodeHelper.decodeFromMiHoYoAPIJSONResult(
             data: data,
             debugTag: "HoYo.getUserGameRolesByCookie()"

--- a/Packages/PZKit/Sources/PZBaseKit/AppUtils/AppStoreMeta.swift
+++ b/Packages/PZKit/Sources/PZBaseKit/AppUtils/AppStoreMeta.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import Defaults
 import Foundation
 import Observation
@@ -55,10 +56,8 @@ public actor ASMetaSputnik: Sendable {
     @discardableResult
     public func updateMeta() async -> Bool {
         guard Date.now.timeIntervalSince1970 - lastTimeCheckingUpdates.timeIntervalSince1970 > 60 else { return false }
-        guard let url = URL(string: Self.apiURLStr) else { return false }
-        guard let (data, _) = try? await URLSession.shared.data(from: url) else { return false }
-        guard let decoded = try? JSONDecoder().decode(ASMetaResult.self, from: data) else { return false }
-        guard let meta = decoded.results.first else { return false }
+        let afReqParsed = AF.request(Self.apiURLStr).serializingDecodable(ASMetaResult.self)
+        guard let meta = try? await afReqParsed.value.results.first else { return false }
         Defaults[.cachedAppStoreMeta] = meta
         return true
     }

--- a/Packages/PZKit/Sources/PZBaseKit/FoundationImpl/FoundationImpl.swift
+++ b/Packages/PZKit/Sources/PZBaseKit/FoundationImpl/FoundationImpl.swift
@@ -2,6 +2,7 @@
 // ====================
 // This code is released under the SPDX-License-Identifier: `AGPL-3.0-or-later`.
 
+import Alamofire
 import CryptoKit
 import Foundation
 
@@ -26,6 +27,12 @@ extension URLRequest {
         }
         print("---------------------------------------------")
         #endif
+    }
+}
+
+extension Alamofire.DataRequest {
+    public func printDebugIntelIfDebugMode() {
+        convertible.urlRequest?.printDebugIntelIfDebugMode()
     }
 }
 


### PR DESCRIPTION
- All other members in the dev team feel more comfortable with AFNetworking (Alamofire) APIs, hence this change.
- However, an exception in the function `[PZAccountKit] HoYo.generateRequest`'s internal DataRequest composition has been kept intact using the URLRequest APIs. This is to make sure the DS calculation result is sane. I'm not familiar with intermediate use of Alamofire APIs, and I decided to let professionals handle this change in this function.