### PR TITLE
PZHelper // Refactor how ProfileManager interacts with SwiftData.

### DIFF
--- a/Packages/PZHelper-Watch/Sources/PZHelper-Watch/Modules/View/ContentView.swift
+++ b/Packages/PZHelper-Watch/Sources/PZHelper-Watch/Modules/View/ContentView.swift
@@ -82,8 +82,6 @@ public struct ContentView: View {
 
     @Environment(\.scenePhase) var scenePhase
 
-    @Environment(\.modelContext) var modelContext
-
     // MARK: Private
 
     @StateObject private var connectivityManager = AppleWatchSputnik.shared

--- a/Packages/PZHelper/Sources/PZHelper/ContentView.swift
+++ b/Packages/PZHelper/Sources/PZHelper/ContentView.swift
@@ -28,11 +28,6 @@ public struct ContentView: View {
                 }
             }
         }
-        .onChange(of: accounts) {
-            Task { @MainActor in
-                await PZProfileActor.shared.syncAllDataToUserDefaults()
-            }
-        }
         #if targetEnvironment(macCatalyst)
         .apply { theContent in
             #if compiler(>=6.0) && canImport(UIKit, _version: 18.0)
@@ -137,14 +132,11 @@ public struct ContentView: View {
         }
     }
 
-    @Query(sort: \PZProfileMO.priority) var accounts: [PZProfileMO]
-
     @Default(.appTabIndex) var appIndex: Int
 
     // MARK: Private
 
     @Environment(\.colorScheme) private var colorScheme
-    @Environment(\.modelContext) private var modelContext
     @StateObject private var tabNavVM = GlobalNavVM.shared
 
     private var tintForCurrentTab: Color {

--- a/Packages/PZHelper/Sources/PZHelper/PZH_Frontends/PZH_Features/ProfileManager/ProfileMgr_SubViews/ProfileBackupRestoreMenu.swift
+++ b/Packages/PZHelper/Sources/PZHelper/PZH_Frontends/PZH_Features/ProfileManager/ProfileMgr_SubViews/ProfileBackupRestoreMenu.swift
@@ -24,20 +24,28 @@ struct ProfileBackupRestoreMenu<T: View>: View {
     // MARK: Public
 
     @ViewBuilder public var body: some View {
-        @Bindable var theVM = theVM
-        let msgPack = theVM.fileSaveActionResultMessagePack
+        @Bindable var vm4ProfileExchange = vm4ProfileExchange
+        let msgPack = vm4ProfileExchange.fileSaveActionResultMessagePack
         Menu {
             Button {
-                theVM.currentExportableDocument = Result.success(.init(prepareAllExportableProfiles()))
+                vm4ProfileExchange.currentExportableDocument = Result.success(
+                    .init(vm4ProfileMgmt.profiles)
+                )
             } label: {
-                Label("profileMgr.exchange.export.menuTitle".i18nPZHelper, systemSymbol: .squareAndArrowUpOnSquare)
+                Label(
+                    "profileMgr.exchange.export.menuTitle".i18nPZHelper,
+                    systemSymbol: .squareAndArrowUpOnSquare
+                )
             }
-            .disabled(profiles.isEmpty)
+            .disabled(vm4ProfileMgmt.profiles.isEmpty)
             Divider()
             Button {
-                theVM.isImporterVisible = true
+                vm4ProfileExchange.isImporterVisible = true
             } label: {
-                Label("profileMgr.exchange.import.menuTitle".i18nPZHelper, systemSymbol: .squareAndArrowDownOnSquare)
+                Label(
+                    "profileMgr.exchange.import.menuTitle".i18nPZHelper,
+                    systemSymbol: .squareAndArrowDownOnSquare
+                )
             }
             if let extraItem {
                 Divider()
@@ -49,26 +57,26 @@ struct ProfileBackupRestoreMenu<T: View>: View {
         .apply { coreContent in
             coreContent
                 .fileImporter(
-                    isPresented: $theVM.isImporterVisible,
+                    isPresented: $vm4ProfileExchange.isImporterVisible,
                     allowedContentTypes: [.json]
                 ) { result in
                     importCompletionHandler(result)
                 }
                 .fileExporter(
-                    isPresented: theVM.isExporterVisible,
-                    document: theVM.getCurrentExportableDocument(),
+                    isPresented: vm4ProfileExchange.isExporterVisible,
+                    document: vm4ProfileExchange.getCurrentExportableDocument(),
                     contentType: .json,
-                    defaultFilename: theVM.defaultFileName
+                    defaultFilename: vm4ProfileExchange.defaultFileName
                 ) { result in
-                    theVM.fileSaveActionResult = result
-                    theVM.currentExportableDocument = nil
+                    vm4ProfileExchange.fileSaveActionResult = result
+                    vm4ProfileExchange.currentExportableDocument = nil
                 }
                 .alert(
                     msgPack.title,
-                    isPresented: theVM.isExportResultAvailable,
+                    isPresented: vm4ProfileExchange.isExportResultAvailable,
                     actions: {
                         Button("sys.ok".i18nBaseKit) {
-                            theVM.fileSaveActionResult = nil
+                            vm4ProfileExchange.fileSaveActionResult = nil
                         }
                     },
                     message: {
@@ -77,24 +85,17 @@ struct ProfileBackupRestoreMenu<T: View>: View {
                 )
         }
         .onDisappear {
-            theVM.currentExportableDocument = nil
+            vm4ProfileExchange.currentExportableDocument = nil
         }
     }
 
     // MARK: Private
 
-    @Environment(\.modelContext) private var modelContext
-    @Query(sort: \PZProfileMO.priority) private var profiles: [PZProfileMO]
-    @StateObject private var theVM = Coordinator()
+    @StateObject private var vm4ProfileExchange = Coordinator()
+    @StateObject private var vm4ProfileMgmt: ProfileManagerVM = .shared
 
     private let importCompletionHandler: (Result<URL, any Error>) -> Void
     private let extraItem: (() -> T)?
-}
-
-extension ProfileBackupRestoreMenu {
-    private func prepareAllExportableProfiles() -> [PZProfileSendable] {
-        profiles.map(\.asSendable)
-    }
 }
 
 // MARK: ProfileBackupRestoreMenu.Coordinator

--- a/Packages/PZHelper/Sources/PZHelper/PZH_Frontends/PZH_Features/TodayDashboard/InAppDailyNoteCardView.swift
+++ b/Packages/PZHelper/Sources/PZHelper/PZH_Frontends/PZH_Features/TodayDashboard/InAppDailyNoteCardView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 struct InAppDailyNoteCardView: View {
     // MARK: Lifecycle
 
-    init(profile: PZProfileMO) {
+    init(profile: PZProfileSendable) {
         self._theVM = .init(
             wrappedValue: DailyNoteViewModel(profile: profile) { dailyNote in
                 #if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
@@ -21,7 +21,7 @@ struct InAppDailyNoteCardView: View {
                     Task {
                         // let accounts = AccountModel.shared.fetchAccountConfigs()
                         try? StaminaLiveActivityController.shared.createResinRecoveryTimerActivity(
-                            for: profile.asSendable,
+                            for: profile,
                             data: dailyNote
                         )
                     }
@@ -58,7 +58,7 @@ struct InAppDailyNoteCardView: View {
                     #if canImport(ActivityKit) && !targetEnvironment(macCatalyst)
                     Menu {
                         EnableLiveActivityButton(
-                            for: theVM.profile.asSendable,
+                            for: theVM.profile,
                             dailyNote: dailyNote
                         )
                     } label: {
@@ -95,7 +95,7 @@ struct InAppDailyNoteCardView: View {
 // MARK: - DailyNoteCardErrorView
 
 private struct DailyNoteCardErrorView: View {
-    public let profile: PZProfileMO
+    public let profile: PZProfileSendable
     public var error: Error
 
     public var body: some View {

--- a/Packages/PZHelper/Sources/PZHelper/PZH_Frontends/RootTabViews/0_AppSettings_SubPages/WatchDataPusherButton.swift
+++ b/Packages/PZHelper/Sources/PZHelper/PZH_Frontends/RootTabViews/0_AppSettings_SubPages/WatchDataPusherButton.swift
@@ -24,14 +24,14 @@ struct WatchDataPusherButton: View {
         if AppleWatchSputnik.isSupported {
             Section {
                 Button {
-                    var accountInfo = "settings.appleWatchPusher.force_push.received".i18nPZHelper
-                    accountInfo += "\n"
-                    for account in pzProfiles {
-                        accountInfo += "\(account.name) (\(account.uidWithGame))\n"
+                    var profileInfo = "settings.appleWatchPusher.force_push.received".i18nPZHelper
+                    profileInfo += "\n"
+                    for profile in theVM.profiles {
+                        profileInfo += "\(profile.name) (\(profile.uidWithGame))\n"
                     }
                     AppleWatchSputnik.shared.sendAccounts(
-                        pzProfiles.map(\.asSendable),
-                        accountInfo
+                        theVM.profiles,
+                        profileInfo
                     )
                 } label: {
                     Label(
@@ -53,5 +53,5 @@ struct WatchDataPusherButton: View {
 
     // MARK: Private
 
-    @Query(sort: \PZProfileMO.priority) private var pzProfiles: [PZProfileMO]
+    @StateObject private var theVM: ProfileManagerVM = .shared
 }

--- a/Packages/PZKit/Sources/PZAccountKit/CloudAccountMO/AccountMO_Base.swift
+++ b/Packages/PZKit/Sources/PZAccountKit/CloudAccountMO/AccountMO_Base.swift
@@ -40,6 +40,21 @@ public protocol ProfileMOBasicProtocol: Codable, ProfileBasicProtocol {
     var uuid: UUID { get set }
 }
 
+extension Array where Element: ProfileMOBasicProtocol {
+    mutating public func fixPrioritySettings(respectExistingPriority: Bool = false) {
+        var newResult = self
+        if respectExistingPriority {
+            newResult.sort { $0.priority < $1.priority }
+        }
+        newResult.indices.forEach {
+            var newObj = newResult[$0]
+            newObj.priority = $0
+            newResult[$0] = newObj
+        }
+        self = newResult
+    }
+}
+
 extension ProfileBasicProtocol {
     public var isValid: Bool {
         true

--- a/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/DailyNoteRelated/PublicViewModels/DailyNoteViewModel.swift
+++ b/Packages/PZKit/Sources/PZAccountKit/HoYoAPIs/DailyNoteRelated/PublicViewModels/DailyNoteViewModel.swift
@@ -18,7 +18,7 @@ public final class DailyNoteViewModel: ObservableObject, Sendable {
     /// Initializes a new instance of the view model.
     ///
     /// - Parameter account: The account for which the daily note will be fetched.
-    public init(profile: PZProfileMO, extraTaskAfterFetch: ((any DailyNoteProtocol) -> Void)? = nil) {
+    public init(profile: PZProfileSendable, extraTaskAfterFetch: ((any DailyNoteProtocol) -> Void)? = nil) {
         self.profile = profile
         self.extraTask = extraTaskAfterFetch
         getDailyNoteUncheck()
@@ -36,7 +36,7 @@ public final class DailyNoteViewModel: ObservableObject, Sendable {
     public private(set) var dailyNoteStatus: Status = .progress(nil)
 
     /// The account for which the daily note is being fetched.
-    public let profile: PZProfileMO
+    public let profile: PZProfileSendable
 
     /// Fetches the daily note and updates the published `dailyNote` property accordingly.
     @MainActor
@@ -62,10 +62,9 @@ public final class DailyNoteViewModel: ObservableObject, Sendable {
         if case let .progress(task) = dailyNoteStatus {
             task?.cancel()
         }
-        let profileSendable = profile.asSendable
         let task = Task { @MainActor in
             do {
-                let result = try await profileSendable.getDailyNote()
+                let result = try await profile.getDailyNote()
                 withAnimation {
                     dailyNoteStatus = .succeed(dailyNote: result, refreshDate: Date())
                 }

--- a/Packages/PZKit/Sources/PZAccountKit/NotificationRelated/NotificationSputnik.swift
+++ b/Packages/PZKit/Sources/PZAccountKit/NotificationRelated/NotificationSputnik.swift
@@ -35,6 +35,24 @@ extension PZNotificationCenter {
         }
     }
 
+    public static func batchDeleteDailyNoteNotification(profiles: Set<PZProfileSendable>, onlyDeleteIfDisabled: Bool) {
+        Task { @MainActor in
+            let requests = await center.pendingNotificationRequests()
+            profiles.forEach { profile in
+                if onlyDeleteIfDisabled {
+                    guard !profile.allowNotification else { return }
+                }
+                center.removePendingNotificationRequests(
+                    withIdentifiers: requests
+                        .map(\.identifier)
+                        .filter { id in
+                            id.contains(profile.uuid.uuidString) || id.contains(profile.uidWithGame)
+                        }
+                )
+            }
+        }
+    }
+
     public static func deleteDailyNoteNotification(of type: DailyNoteNotificationType) async throws {
         let requests = await center.pendingNotificationRequests()
         await center.removePendingNotificationRequests(


### PR DESCRIPTION
- This is to solve a concurrency issue detected by Xcode 26: If a SwiftData database is handled by a dedicated ModelActor, then SwiftUI-based API for SwiftData MUST NOT BE USED. Otherwise, immediate crash on model-context modification.
- The new design is already used in GachaKit a year ago, using a dedicated view model as a task manager to handle all the SwiftData tasks between the ModelActor and the SwiftUI frontend.
